### PR TITLE
Fix link Markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Exact duplicate records were removed using signature based methods.  Algorithms 
 
 ### Data Format:
 
-Crawled data were put into Common Crawl Format, acording to Memex format, using the [CommonCrawlDataDumper] (https://wiki.apache.org/nutch/CommonCrawlDataDumper). The CommonCrawlDataDumper is an Apache Nutch tool that can dump Nutch segments into Common Crawl data format, mapping each crawled-by-Nutch file on a JSON-based data structure. CommonCrawlDataDumper dumps out the files and serialize them with CBOR encoding, a data representation format used in many contexts.
+Crawled data were put into Common Crawl Format, acording to Memex format, using the [CommonCrawlDataDumper](https://wiki.apache.org/nutch/CommonCrawlDataDumper). The CommonCrawlDataDumper is an Apache Nutch tool that can dump Nutch segments into Common Crawl data format, mapping each crawled-by-Nutch file on a JSON-based data structure. CommonCrawlDataDumper dumps out the files and serialize them with CBOR encoding, a data representation format used in many contexts.
 
 Each contributed web crawl has an accompanying JSON file that lists the total records, by mimeType. A program, aggregate.py, aggregates all of the JSON files.  Total records at time of generation are provided below:
 


### PR DESCRIPTION
I believe the line break is causing the link to be displayed as raw markdown. I have a co-worker at NIWA that works with the [Deep South Challenge](http://www.deepsouthchallenge.co.nz/) and may be interested to have a look for their Earth System Models.

Thanks for sharing!
Bruno